### PR TITLE
Add ability to add arguments to Intellij Run Configurations

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/BaseExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BaseExtension.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.common;
 
 import com.google.common.base.Strings;
+import groovy.lang.Closure;
 import net.minecraftforge.gradle.GradleConfigurationException;
 import org.gradle.api.Project;
 
@@ -22,8 +23,13 @@ public class BaseExtension {
     protected int mappingsVersion = -1;
     protected String customVersion = null;
 
+    private final RunConfig runClient;
+    private final RunConfig runServer;
+
     public BaseExtension(BasePlugin<? extends BaseExtension> plugin) {
         this.project = plugin.project;
+        this.runClient = new RunConfig();
+        this.runServer = new RunConfig();
     }
 
     public String getVersion() {
@@ -35,6 +41,18 @@ public class BaseExtension {
 
         // maybe they set the mappings first
         checkMappings();
+    }
+
+    public void clientRunConfig(Closure<RunConfig> c) {
+        c.setResolveStrategy(Closure.DELEGATE_FIRST);
+        c.setDelegate(runClient);
+        c.call();
+    }
+
+    public void serverRunConfig(Closure<RunConfig> c) {
+        c.setResolveStrategy(Closure.DELEGATE_FIRST);
+        c.setDelegate(runServer);
+        c.call();
     }
 
     public String getMcpVersion() {
@@ -186,5 +204,13 @@ public class BaseExtension {
         Arrays.sort(array);
         int foundIndex = Arrays.binarySearch(array, key);
         return foundIndex >= 0 && array[foundIndex] == key;
+    }
+
+    public RunConfig getRunClient() {
+        return runClient;
+    }
+
+    public RunConfig getRunServer() {
+        return runServer;
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/common/RunConfig.java
+++ b/src/main/java/net/minecraftforge/gradle/common/RunConfig.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.gradle.common;
+
+import groovy.lang.GroovyObjectSupport;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class RunConfig extends GroovyObjectSupport {
+    private final List<String> args = new ArrayList<>();
+    private final List<String> jvmArgs = new ArrayList<>();
+
+    public void args(List<String> values) {
+        setArgs(values);
+    }
+
+    public void args(String... values) {
+        args(Arrays.asList(values));
+    }
+
+    public void jvmArgs(List<String> values) {
+        setJvmArgs(values);
+    }
+
+    public void jvmArgs(String... values) {
+        jvmArgs(Arrays.asList(values));
+    }
+
+    private void setArgs(List<String> values) {
+        values.forEach(value -> getArgs().add(Objects.toString(value)));
+    }
+
+    public List<String> getArgs() {
+        return args;
+    }
+
+    private void setJvmArgs(List<String> values) {
+        getJvmArgs().addAll(values);
+    }
+
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -1,12 +1,12 @@
 package net.minecraftforge.gradle.user;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.common.BaseExtension;
 import net.minecraftforge.gradle.common.BasePlugin;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
@@ -32,10 +32,7 @@ import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -46,12 +43,16 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static net.minecraftforge.gradle.common.Constants.*;
 import static net.minecraftforge.gradle.user.UserConstants.*;
 
 public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin<T> {
+    private static final List<String> INTERNAL_JVM_ARGS = ImmutableList.of("-Xmx6G", "-Xms256M", "-Dfml.ignoreInvalidMinecraftCertificates=true");
+
     @SuppressWarnings("serial")
     @Override
     public void applyPlugin() {
@@ -503,17 +504,32 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
                                 {
                                         "Minecraft Client",
                                         GRADLE_START_CLIENT,
-                                        "-Xmx6G -Xms256M",
-                                        Joiner.on(' ').join(getClientRunArgs())
+                                        setToString(getClientJvmArgs()),
+                                        setToString(getClientArgs())
                                 },
                         new String[]
                                 {
                                         "Minecraft Server",
                                         GRADLE_START_SERVER,
-                                        "-Xmx6G -Xms256M -Dfml.ignoreInvalidMinecraftCertificates=true",
-                                        Joiner.on(' ').join(getServerRunArgs())
+                                        setToString(getServerJvmArgs()),
+                                        setToString(getServerArgs())
                                 }
                 };
+
+        // Clearing old MC configurations
+        NodeList children = root.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node item = children.item(i);
+            if(!(item instanceof Element)) continue;
+
+            Element elem = (Element) item;
+            for (String[] data : config) {
+                if (elem.getAttribute("name").equals(data[0])) {
+                    root.removeChild(item);
+                    break;
+                }
+            }
+        }
 
         for (String[] data : config) {
             Element child = add(root, "configuration",
@@ -546,6 +562,34 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         File f = delayedFile("{RUN_DIR}").call();
         if (!f.exists())
             f.mkdirs();
+    }
+
+    private Set<String> getClientArgs() {
+        return collectArgs(getMcExtension(project).getRunClient().getArgs(), getClientRunArgs());
+    }
+
+    private Set<String> getClientJvmArgs() {
+        return collectArgs(getMcExtension(project).getRunClient().getJvmArgs(), INTERNAL_JVM_ARGS);
+    }
+
+    private Set<String> getServerArgs() {
+        return collectArgs(getMcExtension(project).getRunServer().getArgs(), getServerRunArgs());
+    }
+
+    private Set<String> getServerJvmArgs() {
+        return collectArgs(getMcExtension(project).getRunServer().getJvmArgs(), INTERNAL_JVM_ARGS);
+    }
+
+    private String setToString(Set<String> strs) {return String.join(" ", strs);}
+
+    private static BaseExtension getMcExtension(Project project) {
+        return (BaseExtension) project.getExtensions().getByName(Constants.EXT_NAME_MC);
+    }
+
+    private Set<String> collectArgs(List<String> userArgs, Iterable<String> internalArgs) {
+        Set<String> args = new HashSet<>(userArgs);
+        internalArgs.forEach(args::add);
+        return args;
     }
 
     private Element add(Element parent, String name, String... values) {
@@ -786,8 +830,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             });
             exec.doFirst(new MakeDirExist(delayedFile("{RUN_DIR}")));
             exec.setMain(GRADLE_START_CLIENT);
-            exec.jvmArgs("-Xmx6G", "-Xms256M", "-Dfml.ignoreInvalidMinecraftCertificates=true");
-            exec.args(getClientRunArgs());
+            exec.jvmArgs(getClientJvmArgs());
+            exec.args(getClientArgs());
             exec.setStandardOutput(System.out);
             exec.setErrorOutput(System.err);
 
@@ -807,8 +851,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             });
             exec.doFirst(new MakeDirExist(delayedFile("{RUN_DIR}")));
             exec.setMain(GRADLE_START_SERVER);
-            exec.jvmArgs("-Xmx6G", "-Xms256M", "-Dfml.ignoreInvalidMinecraftCertificates=true");
-            exec.args(getServerRunArgs());
+            exec.jvmArgs(getServerJvmArgs());
+            exec.args(getServerArgs());
             exec.setStandardOutput(System.out);
             exec.setStandardInput(System.in);
             exec.setErrorOutput(System.err);

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -43,9 +43,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static net.minecraftforge.gradle.common.Constants.*;
 import static net.minecraftforge.gradle.user.UserConstants.*;
@@ -564,31 +563,32 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             f.mkdirs();
     }
 
-    private Set<String> getClientArgs() {
+    private List<String> getClientArgs() {
         return collectArgs(getMcExtension(project).getRunClient().getArgs(), getClientRunArgs());
     }
 
-    private Set<String> getClientJvmArgs() {
+    private List<String> getClientJvmArgs() {
         return collectArgs(getMcExtension(project).getRunClient().getJvmArgs(), INTERNAL_JVM_ARGS);
     }
 
-    private Set<String> getServerArgs() {
+    private List<String> getServerArgs() {
         return collectArgs(getMcExtension(project).getRunServer().getArgs(), getServerRunArgs());
     }
 
-    private Set<String> getServerJvmArgs() {
+    private List<String> getServerJvmArgs() {
         return collectArgs(getMcExtension(project).getRunServer().getJvmArgs(), INTERNAL_JVM_ARGS);
     }
 
-    private String setToString(Set<String> strs) {return String.join(" ", strs);}
+    private String setToString(List<String> strs) {return String.join(" ", strs);}
 
     private static BaseExtension getMcExtension(Project project) {
         return (BaseExtension) project.getExtensions().getByName(Constants.EXT_NAME_MC);
     }
 
-    private Set<String> collectArgs(List<String> userArgs, Iterable<String> internalArgs) {
-        Set<String> args = new HashSet<>(userArgs);
+    private List<String> collectArgs(List<String> userArgs, Iterable<String> internalArgs) {
+        List<String> args = new ArrayList<>();
         internalArgs.forEach(args::add);
+        args.addAll(userArgs);
         return args;
     }
 


### PR DESCRIPTION
In `minecraft` closure there're now two configuration closures: `clientRunConfig` & `serverRunConfig`. All closures are optional.
In both of them you can set args and jvmArgs (params are: `String...` or `List<String>`).
Each call will ADD (not replace) new arguments to the existing ones.

Example:

```groovy
minecraft  {
    ...

    clientRunConfig {
        jvmArgs("-Dmixin.debug=true")
        args("--mixin", "mixin.test.json")
    }

    serverRunConfig {}
}
```

Example of spreading arguments:
```groovy
minecraft {
     ...

    def myJvmArgs = ["-Dmixin.debug=true"]
    clientRunConfig {
        jvmArgs(myJvmArgs)
    }

    serverRunConfig {
        jvmArgs(myJvmArgs)
    }
}
```

_Of course you will need to remove your old `runClient` and `runServer` closures in build.gradle._