### PR TITLE
Automatic module choice in IJ Run Configurations upon genIntellijRuns

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -503,15 +503,15 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
                                 {
                                         "Minecraft Client",
                                         GRADLE_START_CLIENT,
-                                        setToString(getClientJvmArgs()),
-                                        setToString(getClientArgs())
+                                        listToString(getClientJvmArgs()),
+                                        listToString(getClientArgs())
                                 },
                         new String[]
                                 {
                                         "Minecraft Server",
                                         GRADLE_START_SERVER,
-                                        setToString(getServerJvmArgs()),
-                                        setToString(getServerArgs())
+                                        listToString(getServerJvmArgs()),
+                                        listToString(getServerArgs())
                                 }
                 };
 
@@ -585,7 +585,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         return collectArgs(getMcExtension(project).getRunServer().getJvmArgs(), INTERNAL_JVM_ARGS);
     }
 
-    private String setToString(List<String> strs) {return String.join(" ", strs);}
+    private String listToString(List<String> strs) {return String.join(" ", strs);}
 
     private static BaseExtension getMcExtension(Project project) {
         return (BaseExtension) project.getExtensions().getByName(Constants.EXT_NAME_MC);

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
 import net.minecraftforge.gradle.common.BasePlugin;
@@ -46,7 +45,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import static net.minecraftforge.gradle.common.Constants.*;
 import static net.minecraftforge.gradle.user.UserConstants.*;
@@ -515,6 +513,12 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
                                 }
                 };
 
+        String projectName = project.getName();
+        String moduleName = ((IdeaModel) project.getExtensions().getByName("idea")).getModule().getName();
+        // if module name is not set in build.gradle it will be the same as project name by default,
+        // but since we have main module by default, we add it if the module name was not overridden by user.
+        String runModule = projectName.equals(moduleName) ? projectName + ".main" : projectName + "." + moduleName;
+
         for (String[] data : config) {
             Element child = add(root, "configuration",
                     "default", "false",
@@ -537,7 +541,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             add(child, "option", "name", "ENABLE_SWING_INSPECTOR", "value", "false");
             add(child, "option", "name", "ENV_VARIABLES");
             add(child, "option", "name", "PASS_PARENT_ENVS", "value", "true");
-            add(child, "module", "name", ((IdeaModel) project.getExtensions().getByName("idea")).getModule().getName());
+            add(child, "module", "name", runModule);
             add(child, "envs");
             add(child, "RunnerSettings", "RunnerId", "Run");
             add(child, "ConfigurationWrapper", "RunnerId", "Run");


### PR DESCRIPTION
Fixes the need of manually module setting in Run Configurations, if no module name was defined in build.gradle.

_Can have weird behaviour if `Clearing old MC configurations` part from https://github.com/GTNewHorizons/ForgeGradle/pull/9 is not applied._