### PR TITLE
fix runtime vs implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,3 +193,9 @@ publishing {
 // write out version so it's convenient for doc deployment
 file('build').mkdirs()
 file('build/version.txt').text = version;
+
+tasks.register('setupCIWorkspace') {
+    doFirst {
+        println 'not necessary'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ group = 'net.minecraftforge.gradle'
 
 version = gitVersion()
 
+// Fix Jenkins' Git: chmod a file should not be detected as a change and append a '.dirty' to the version
+'git config core.fileMode false'.execute()
+
 archivesBaseName = 'ForgeGradle'
 targetCompatibility = '1.8'
 sourceCompatibility = '1.8'
@@ -18,30 +21,29 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        name = "forge"
-        url = "https://maven.minecraftforge.net/"
+        name 'forge'
+        url 'https://maven.minecraftforge.net/'
     }
 	maven {
-		name = "GT forge Mirror"
-		url = "https://gregtech.overminddl1.com/"
+		name 'GT forge Mirror'
+		url 'https://gregtech.overminddl1.com/'
 	}	
     maven {
         // because Srg2Source needs an eclipse dependency.
-        name = "eclipse"
-        url = "https://repo.eclipse.org/content/groups/eclipse/"
+        name 'eclipse'
+        url 'https://repo.eclipse.org/content/groups/eclipse/'
     }
     maven {
         // because SpecialSource doesn't have a full release
-        name = "sonatype"
-        url = "https://oss.sonatype.org/content/repositories/snapshots/"
+        name 'sonatype'
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
     }
     maven {
-        name = "mojang"
-        url = "https://libraries.minecraft.net/"
+        name 'mojang'
+        url 'https://libraries.minecraft.net/'
     }
     maven {
-        name = "jitpack"
-        url = "https://jitpack.io"
+        url 'https://jitpack.io'
     }
 }
 

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -257,10 +257,6 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
      */
     protected abstract Iterable<String> getServerRunArgs();
 
-//    protected abstract void configureCISetup(Task task);
-//    protected abstract void configureDevSetup(Task task);
-//    protected abstract void configureDecompSetup(Task task);
-
     @Override
     public String resolve(String pattern, Project project, T exten) {
         pattern = super.resolve(pattern, project, exten);
@@ -809,7 +805,6 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         }
     }
 
-    @SuppressWarnings("serial")
     private class MakeDirExist extends Closure<Boolean> {
         DelayedFile path;
 
@@ -887,7 +882,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
                 @Override
                 public void execute(Object o) {
                     project.getLogger().error("");
-                    project.getLogger().error("THIS TASK WILL BE DEP RECATED SOON!");
+                    project.getLogger().error("THIS TASK WILL BE DEPRECATED SOON!");
                     project.getLogger().error("Instead use the runClient task, with the --debug-jvm option");
                     if (!project.getGradle().getGradleVersion().equals("1.12")) {
                         project.getLogger().error("You may have to update to Gradle 1.12");
@@ -938,7 +933,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             exec.setDebug(true);
 
             exec.setGroup("ForgeGradle");
-            exec.setDescription("Runs the Minecraft serevr in debug mode");
+            exec.setDescription("Runs the Minecraft server in debug mode");
 
             exec.dependsOn("makeStart");
         }
@@ -1122,28 +1117,28 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
         JavaExec exec = (JavaExec) project.getTasks().getByName("runClient");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName("runtimeClasspath"));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("runServer");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName("runtimeClasspath"));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugClient");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName("runtimeClasspath"));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugServer");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName("runtimeClasspath"));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
@@ -1210,7 +1205,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
     protected abstract void doVersionChecks(String version);
 
     /**
-     * Returns a file in the DirtyDir if the deobfuscation task is dirty. Otherwise returns the cached one.
+     * Returns a file in the DirtyDir if the deobfuscation task is dirty. Otherwise, returns the cached one.
      *
      * @param name       the name..
      * @param classifier the classifier
@@ -1222,7 +1217,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
     }
 
     /**
-     * Returns a file in the DirtyDir if the deobfuscation task is dirty. Otherwise returns the cached one.
+     * Returns a file in the DirtyDir if the deobfuscation task is dirty. Otherwise, returns the cached one.
      *
      * @param name         the name..
      * @param classifier   the classifier
@@ -1265,7 +1260,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         if (!git.exists()) {
             git.getParentFile().mkdir();
             try {
-                Files.write("#Seriously guys, stop commiting this to your git repo!\r\n*".getBytes(), git);
+                Files.write("#Seriously guys, stop committing this to your git repo!\r\n*".getBytes(), git);
             } catch (IOException e) {
             }
         }


### PR DESCRIPTION
Gradle supports (as deprecated) runtime and compile - and as "new and proper" api and implementation.

This fixes ForgeGradle to correctly use runtimeClasspath instead of assuming "runtime" is present (which is not set in modern Gradle)

Tested with both `compile` and `implementation`. (`api` is equivalent to `compileOnly` and so wouldn't appear in either)