### PR TITLE
Use new mojang resource API

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -13,8 +13,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -45,14 +47,11 @@ public class Constants {
     };
 
     // urls
-    public static final String MC_JSON_URL      = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.json";
-    public static final String MC_JAR_URL       = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.jar";
-    public static final String MC_SERVER_URL    = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/minecraft_server.{MC_VERSION}.jar";
+    public static final String URL_MC_MANIFEST  = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
     public static final String MCP_URL          = "https://files.minecraftforge.net/fernflower-fix-1.0.zip";
     public static final String ASSETS_URL       = "https://resources.download.minecraft.net";
     public static final String LIBRARY_URL      = "https://libraries.minecraft.net/";
     public static final String FORGE_MAVEN      = "https://maven.minecraftforge.net";
-    public static final String ASSETS_INDEX_URL = "https://s3.amazonaws.com/Minecraft.Download/indexes/{ASSET_INDEX}.json";
 
     // MCP things
     public static final String CONFIG_MCP_DATA  = "mcpSnapshotDataConfig";
@@ -243,5 +242,66 @@ public class Constants {
             throw new RuntimeException("Resource " + resource + " not found");
 
         return url;
+    }
+    
+    /**
+     * Resolves the supplied object to a string.
+     * If the input is null, this will return null.
+     * Closures and Callables are called with no arguments.
+     * Arrays use Arrays.toString().
+     * File objects return their absolute paths.
+     * All other objects have their toString run.
+     * @param obj Object to resolve
+     * @return resolved string
+     */
+    @SuppressWarnings("rawtypes")
+    public static String resolveString(Object obj)
+    {
+        if (obj == null)
+            return null;
+
+        // stop early if its the right type. no need to do more expensive checks
+        if (obj instanceof String)
+            return (String) obj;
+
+        if (obj instanceof Closure)
+            return resolveString(((Closure) obj).call());// yes recursive.
+        if (obj instanceof Callable)
+        {
+            try
+            {
+                return resolveString(((Callable) obj).call());
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+        }
+        else if (obj instanceof File)
+            return ((File) obj).getAbsolutePath();
+
+        // arrays
+        else if (obj.getClass().isArray())
+        {
+            if (obj instanceof Object[])
+                return Arrays.toString(((Object[]) obj));
+            else if (obj instanceof byte[])
+                return Arrays.toString(((byte[]) obj));
+            else if (obj instanceof char[])
+                return Arrays.toString(((char[]) obj));
+            else if (obj instanceof int[])
+                return Arrays.toString(((int[]) obj));
+            else if (obj instanceof float[])
+                return Arrays.toString(((float[]) obj));
+            else if (obj instanceof double[])
+                return Arrays.toString(((double[]) obj));
+            else if (obj instanceof long[])
+                return Arrays.toString(((long[]) obj));
+            else
+                return obj.getClass().getSimpleName();
+        }
+
+        else
+            return obj.toString();
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/dev/DevBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevBasePlugin.java
@@ -96,7 +96,13 @@ public abstract class DevBasePlugin extends BasePlugin<DevExtension> {
         task1 = makeTask("updateJson", DownloadTask.class);
         {
             task1.getOutputs().upToDateWhen(Constants.CALL_FALSE);
-            task1.setUrl(delayedString(Constants.MC_JSON_URL));
+            task1.setUrl(new Closure<String>(null, null) {
+                @Override
+                public String call()
+                {
+                    return mcManifest.get(getExtension().getVersion()).url;
+                }
+            });
             task1.setOutput(delayedFile(DevConstants.JSON_BASE));
             task1.setDoesCache(false);
             task1.doLast(new Closure<Boolean>(project) {
@@ -282,7 +288,7 @@ public abstract class DevBasePlugin extends BasePlugin<DevExtension> {
             if (version == null) {
                 File jsonFile = devJson.call().getAbsoluteFile();
                 try {
-                    version = JsonFactory.loadVersion(jsonFile, jsonFile.getParentFile());
+                    version = JsonFactory.loadVersion(jsonFile, delayedString("{MC_VERSION}").call(), jsonFile.getParentFile());
                 } catch (Exception e) {
                     project.getLogger().error("" + jsonFile + " could not be parsed");
                     Throwables.propagate(e);

--- a/src/main/java/net/minecraftforge/gradle/json/MojangManifestAdapter.java
+++ b/src/main/java/net/minecraftforge/gradle/json/MojangManifestAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+  * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.minecraftforge.gradle.json;
+
+import com.google.common.collect.Maps;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import net.minecraftforge.gradle.json.version.ManifestVersion;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public class MojangManifestAdapter implements JsonDeserializer<Map<String, ManifestVersion>>
+{
+    @Override
+    public Map<String, ManifestVersion> deserialize(JsonElement json, Type type, JsonDeserializationContext context) throws JsonParseException
+    {
+        Map<String, ManifestVersion> out = Maps.newHashMap();
+
+        for (JsonElement element : json.getAsJsonObject().get("versions").getAsJsonArray())
+        {
+            ManifestVersion version = context.deserialize(element, ManifestVersion.class);
+            out.put(version.id, version);
+        }
+
+        return out;
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/AssetIndexRef.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/AssetIndexRef.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.gradle.json.version;
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+
+public class AssetIndexRef
+{
+    public String id, sha1, url;
+    public int size, totalSize;
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/Download.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/Download.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.gradle.json.version;
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+
+public class Download
+{
+    String sha1, url;
+    int size;
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/ManifestVersion.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/ManifestVersion.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.gradle.json.version;
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+
+public class ManifestVersion
+{
+    public String id, type, time, releaseTime, url;
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/Version.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/Version.java
@@ -3,6 +3,7 @@ package net.minecraftforge.gradle.json.version;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class Version {
     public String id;
@@ -15,9 +16,9 @@ public class Version {
     public String mainClass;
     public int minimumLauncherVersion;
     public String incompatibilityReason;
-    private String assets;
+    public AssetIndexRef assetIndex;
+    private Map<String, Download> downloads;
     public List<OSRule> rules;
-
     private List<Library> _libraries;
 
     public List<Library> getLibraries() {
@@ -32,28 +33,37 @@ public class Version {
         }
         return _libraries;
     }
-
     public String getAssets() {
-        return assets == null ? "legacy" : assets;
+        return assetIndex.id;
+    }
+    public String getClientUrl()
+    {
+        return downloads.get("client").url;
     }
 
+    public String getServerUrl()
+    {
+        return downloads.get("server").url;
+    }
     /**
      * Populates this instance with information from another version json.
      *
      * @param version Version json to extend from
      */
     public void extendFrom(Version version) {
-        // strings. repalce if null.
+        // strings. replace if null.
         if (minecraftArguments == null)
             minecraftArguments = version.minecraftArguments;
         if (mainClass == null)
             mainClass = version.mainClass;
         if (incompatibilityReason == null)
             incompatibilityReason = version.incompatibilityReason;
-        if (assets == null)
-            assets = version.assets;
+        if (assetIndex == null)
+            assetIndex = version.assetIndex;
+        if (downloads == null)
+            downloads = version.downloads;
 
-        // lists.  repalce if null, add if not.
+        // lists.  replace if null, add if not.
         if (libraries == null)
             libraries = version.libraries;
         else if (version.libraries != null)

--- a/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/DownloadTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/DownloadTask.java
@@ -13,7 +13,7 @@ import java.net.URL;
 
 public class DownloadTask extends CachedTask {
     @Input
-    private DelayedString url;
+    private Object url;
 
     @OutputFile
     @Cached
@@ -60,10 +60,10 @@ public class DownloadTask extends CachedTask {
     }
 
     public String getUrl() {
-        return url.call();
+        return Constants.resolveString(url);
     }
 
-    public void setUrl(DelayedString url) {
+    public void setUrl(Object url) {
         this.url = url;
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/tasks/dev/GenDevProjectsTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/dev/GenDevProjectsTask.java
@@ -49,7 +49,7 @@ public class GenDevProjectsTask extends DefaultTask {
     }
 
     private void parseJson() throws IOException {
-        Version version = JsonFactory.loadVersion(getJson(), getJson().getParentFile());
+        Version version = JsonFactory.loadVersion(getJson(), mcVersion.call(), getJson().getParentFile());
 
         for (Library lib : version.getLibraries()) {
             if (lib.name.contains("fixed") || lib.natives != null || lib.extract != null) {

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -362,7 +362,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
     private void readAndApplyJson(File file, String depConfig, String nativeConfig, Logger log) {
         if (version == null) {
             try {
-                version = JsonFactory.loadVersion(file, delayedFile(Constants.JSONS_DIR).call());
+                version = JsonFactory.loadVersion(file, delayedString("{MC_VERSION}").call(), delayedFile(Constants.JSONS_DIR).call());
             } catch (Exception e) {
                 log.error("" + file + " could not be parsed");
                 Throwables.propagate(e);

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -1017,7 +1017,13 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
         // grab the json && read dependencies
         if (getDevJson().call().exists()) {
-            readAndApplyJson(getDevJson().call(), CONFIG_DEPS, CONFIG_NATIVES, project.getLogger());
+            if(new File(delayedFile(Constants.JSONS_DIR).call(), delayedString("{MC_VERSION}").call() + ".json").isFile()) {
+                readAndApplyJson(getDevJson().call(), CONFIG_DEPS, CONFIG_NATIVES, project.getLogger());
+            } else {
+                // the version json is missing.
+                // extractUserDev runs after getVersionJson, and calls readAndApplyJson in its doLate hook; make sure it runs
+                project.getTasks().getByName("extractUserDev").getOutputs().upToDateWhen(Constants.CALL_FALSE);
+            }
         }
 
         delayedTaskConfig();

--- a/src/main/resources/GradleStart.java
+++ b/src/main/resources/GradleStart.java
@@ -188,7 +188,7 @@ public class GradleStart extends GradleStartCommon {
     }
 
     private static class AssetIndex {
-        public boolean virtual;
+        public boolean virtual = false; // sane default
         public Map<String, AssetEntry> objects;
 
         public static class AssetEntry {


### PR DESCRIPTION
Fixes the infamous "response 403" error.

Tested to work with the `setupDecompWorkspace` task of GT5u, both with a clean cache and with one that was corrupted from a failed run using ForgeGradle 1.2.9-GTNH.