### PR TITLE
Make tasks that need the version json depend on extractUserDev

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -1154,6 +1154,13 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             t.replace(getExtension().getReplacements());
             t.include(getExtension().getIncludes());
         }
+        
+        // make tasks that need the version json depend on extractUserDev (which is where the json gets loaded)
+        {
+            project.getTasks().getByName("downloadClient").dependsOn(project.getTasks().getByName("extractUserDev"));
+            project.getTasks().getByName("downloadServer").dependsOn(project.getTasks().getByName("extractUserDev"));
+            project.getTasks().getByName("getAssetsIndex").dependsOn(project.getTasks().getByName("extractUserDev"));
+        }
     }
 
     /**


### PR DESCRIPTION
The task graph wasn't set up properly in #16, which caused the `setupCIWorkspace` and `setupDevWorkspace` tasks to fail when run with a fresh Gradle cache. `setupDecompWorkspace` only worked by chance.

This PR makes tasks that need the version json depend on the task that loads the version JSON, which is also how it works in FG2.