### PR TITLE
Update SpecialSource and ASM to ASM9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ sourceCompatibility = '1.8'
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url 'https://jitpack.io' }
     maven {
         name 'forge'
         url 'https://maven.minecraftforge.net/'
@@ -42,7 +43,6 @@ repositories {
         name 'mojang'
         url 'https://libraries.minecraft.net/'
     }
-    maven { url 'https://github.com/drori200/maven/raw/main' }
 }
 
 jar {
@@ -78,7 +78,8 @@ dependencies {
     compile 'com.google.code.gson:gson:2.2.4' // Used instead of Argo for building changelog.
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
 
-    compile 'net.md-5:SpecialSource-custom:1.7.3' // deobf and reobs
+    //Custom version of SpecialSource which uses ASM 9
+    compile 'com.github.drori200:SpecialSource:1.7.4' // deobf and reobs
 
     // because curse
     compile 'org.apache.httpcomponents:httpclient:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ repositories {
         name 'mojang'
         url 'https://libraries.minecraft.net/'
     }
+    maven { url 'https://github.com/drori200/maven/raw/main' }
 }
 
 jar {
@@ -60,11 +61,12 @@ dependencies {
     compile gradleApi()
 
     // moved to the beginning to be the overrider
-    classpath 'org.ow2.asm:asm:9.0'
-    classpath 'org.ow2.asm:asm-tree:9.0'
-    classpath 'org.ow2.asm:asm-xml:6.2.1'
-    classpath 'org.ow2.asm:asm-util:9.0'
-    classpath 'org.ow2.asm:asm-commons:9.0'
+    compile 'org.ow2.asm:asm:9.4'
+    compile 'org.ow2.asm:asm-tree:9.4'
+    compile 'org.ow2.asm:asm-xml:6.2.1'
+    compile 'org.ow2.asm:asm-util:9.4'
+    compile 'org.ow2.asm:asm-commons:9.4'
+
     compile 'com.google.guava:guava:18.0'
 
     compile 'net.sf.opencsv:opencsv:2.3' // reading CSVs.. also used by SpecialSource
@@ -76,7 +78,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.2.4' // Used instead of Argo for building changelog.
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
 
-    compile 'net.md-5:SpecialSource:1.7.3' // deobf and reobs
+    compile 'net.md-5:SpecialSource-custom:1.7.3' // deobf and reobs
 
     // because curse
     compile 'org.apache.httpcomponents:httpclient:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
 
     //Custom version of SpecialSource which uses ASM 9
-    compile 'com.github.drori200:SpecialSource:1.7.4' // deobf and reobs
+    compile 'com.github.GTNewHorizons:SpecialSource:1.7.4' // deobf and reobs
 
     // because curse
     compile 'org.apache.httpcomponents:httpclient:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ sourceCompatibility = '1.8'
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url 'https://jitpack.io' }
     maven {
         name 'forge'
         url 'https://maven.minecraftforge.net/'
@@ -28,7 +27,12 @@ repositories {
 	maven {
 		name 'GT forge Mirror'
 		url 'https://gregtech.overminddl1.com/'
-	}	
+	}
+    maven {
+        // GTNH SpecialSource Fork
+        name = "GTNH Maven"
+        url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
+    }
     maven {
         // because Srg2Source needs an eclipse dependency.
         name 'eclipse'
@@ -79,7 +83,7 @@ dependencies {
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
 
     //Custom version of SpecialSource which uses ASM 9
-    compile 'com.github.GTNewHorizons:SpecialSource:1.7.4' // deobf and reobs
+    compile 'com.github.GTNewHorizons:SpecialSource:1.7.5' // deobf and reobs
 
     // because curse
     compile 'org.apache.httpcomponents:httpclient:4.3.3'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,11 @@ dependencies {
     compile gradleApi()
 
     // moved to the beginning to be the overrider
-    compile 'org.ow2.asm:asm-debug-all:5.0.3'
+    classpath 'org.ow2.asm:asm:9.0'
+    classpath 'org.ow2.asm:asm-tree:9.0'
+    classpath 'org.ow2.asm:asm-xml:6.2.1'
+    classpath 'org.ow2.asm:asm-util:9.0'
+    classpath 'org.ow2.asm:asm-commons:9.0'
     compile 'com.google.guava:guava:18.0'
 
     compile 'net.sf.opencsv:opencsv:2.3' // reading CSVs.. also used by SpecialSource


### PR DESCRIPTION
This PR intends to fix an issue i was running into where if trying to shade a library that was compiled against a later version than java 8 would result in a complete nonsense of an error

The fix for this was to update the ASM version of SpecialSource and FG's ASM version to the latest version.

Currently SpecialSource is being built off the github using Jitpack.